### PR TITLE
refactor(web): slice instead of substring

### DIFF
--- a/web/src/app/api/token/route.ts
+++ b/web/src/app/api/token/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: Request) {
     },
   }: PlaygroundState = await request.json();
 
-  const roomName = Math.random().toString(36).substring(7);
+  const roomName = Math.random().toString(36).slice(7);
   const apiKey = process.env.LIVEKIT_API_KEY;
   const apiSecret = process.env.LIVEKIT_API_SECRET;
   if (!apiKey || !apiSecret) {


### PR DESCRIPTION
This is not required, but a good convention across the ecosystem.

For example,

*Ref*: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-string-slice.md

> [String#substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) and [String#substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) are the two lesser known legacy ways to slice a string. It's better to use [String#slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) as it's a more popular option with clearer behavior that has a consistent [Array counterpart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).