### PR TITLE
Add transcript timestamps and download

### DIFF
--- a/web/src/components/instructions.tsx
+++ b/web/src/components/instructions.tsx
@@ -19,7 +19,7 @@ export function Instructions() {
     <div
       className={`flex flex-1 flex-col w-full gap-[4px] border p-4 rounded-lg ${
         isFocused ? "ring-1" : "ring-0"
-      } h-[70vh] overflow-y-auto`}
+      } h-[200px] overflow-y-auto`}
     >
       <div className="flex justify-between items-center mb-2">
         <div className="flex items-center">

--- a/web/src/components/instructions.tsx
+++ b/web/src/components/instructions.tsx
@@ -19,7 +19,7 @@ export function Instructions() {
     <div
       className={`flex flex-1 flex-col w-full gap-[4px] border p-4 rounded-lg ${
         isFocused ? "ring-1" : "ring-0"
-      } h-[200px] overflow-y-auto`}
+      } h-[70vh] overflow-y-auto`}
     >
       <div className="flex justify-between items-center mb-2">
         <div className="flex items-center">

--- a/web/src/components/transcript.tsx
+++ b/web/src/components/transcript.tsx
@@ -75,7 +75,7 @@ export function Transcript({
 
     displayTranscriptions.forEach(({ segment, participant, timestamp }) => {
       const csvRow = [
-        new Date(timestamp).toLocaleTimeString([], {
+        new Date(timestamp || 0).toLocaleTimeString([], {
           hour: '2-digit',
           minute: '2-digit',
           second: '2-digit',
@@ -149,7 +149,7 @@ export function Transcript({
                             : "text-right block"
                         }`}
                       >
-                        {new Date(timestamp).toLocaleTimeString([], {
+                        {new Date(timestamp || 0).toLocaleTimeString([], {
                           hour: "2-digit",
                           minute: "2-digit",
                           second: '2-digit',

--- a/web/src/components/transcript.tsx
+++ b/web/src/components/transcript.tsx
@@ -137,7 +137,7 @@ export function Transcript({
                       "flex w-max max-w-[75%] flex-col gap-2 rounded-lg px-3 py-2 text-sm",
                       participant?.isAgent
                         ? "bg-neutral-100 text-[#09090B]"
-                        : "ml-auto border border-neutral-300"
+                        : "ml-auto border border-neutral-300",
                     )}
                   >
                     <div className="flex flex-col">

--- a/web/src/components/transcript.tsx
+++ b/web/src/components/transcript.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils";
 import { useAgent } from "@/hooks/use-agent";
 import { useEffect, useRef, RefObject, useState } from "react";
+// import { FaDownload } from 'react-icons/fa';
 
 export function Transcript({
   scrollContainerRef,
@@ -19,7 +20,7 @@ export function Transcript({
 
   const handleScrollVisibility = (
     container: HTMLElement,
-    scrollButton: HTMLButtonElement,
+    scrollButton: HTMLButtonElement
   ) => {
     const distanceFromBottom = calculateDistanceFromBottom(container);
     const shouldShowButton = distanceFromBottom > 100;
@@ -69,10 +70,57 @@ export function Transcript({
     }
   }, [scrollButtonRef]);
 
+  const handleDownloadTranscript = () => {
+    // Create CSV content
+    let csvContent = "Timestamp,Participant,Text\n";
+
+    displayTranscriptions.forEach(({ segment, participant, timestamp }) => {
+      const csvRow = [
+        new Date(timestamp).toLocaleTimeString([], {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+          hour12: false
+        }),
+        participant?.isAgent ? "Agent" : "User",
+        `"${segment.text.trim().replace(/"/g, '""')}"`, // Escape quotes in the text
+      ].join(",");
+
+      csvContent += csvRow + "\n";
+    });
+
+    // Create Blob
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+
+    // Create download link
+    const link = document.createElement("a");
+    if (link.download !== undefined) {
+      const url = URL.createObjectURL(blob);
+      link.setAttribute("href", url);
+      link.setAttribute(
+        "download",
+        `transcript_${new Date().toISOString()}.csv`
+      );
+      link.style.visibility = "hidden";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+    console.log("Downloading transcript...");
+  };
+
   return (
     <>
-      <div className="flex items-center text-xs font-semibold uppercase tracking-widest sticky top-0 left-0 bg-white w-full p-4">
-        Transcript
+      <div className="flex items-center justify-between sticky top-0 left-0 bg-white w-full p-4">
+        <h2 className="text-xs font-semibold uppercase tracking-widest">
+          Transcript
+        </h2>
+        <button
+          onClick={handleDownloadTranscript}
+          className="inline-flex text-xs font-semibold uppercase tracking-widest items-center justify-center whitespace-nowrap rounded-md transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-950 disabled:pointer-events-none disabled:opacity-50 dark:focus-visible:ring-neutral-300 text-neutral-50 shadow hover:bg-neutral-900/90 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-neutral-50/90 h-9 px-4 py-2 text-sm font-semibold bg-oai-green"
+        >
+          <span>Download</span>
+        </button>
       </div>
       <div className="p-4 min-h-[300px] relative">
         {displayTranscriptions.length === 0 ? (
@@ -82,7 +130,7 @@ export function Transcript({
         ) : (
           <div className="space-y-4">
             {displayTranscriptions.map(
-              ({ segment, participant, publication }) =>
+              ({ segment, participant, publication, timestamp }) =>
                 segment.text.trim() !== "" && (
                   <div
                     key={segment.id}
@@ -90,12 +138,27 @@ export function Transcript({
                       "flex w-max max-w-[75%] flex-col gap-2 rounded-lg px-3 py-2 text-sm",
                       participant?.isAgent
                         ? "bg-neutral-100 text-[#09090B]"
-                        : "ml-auto border border-neutral-300",
+                        : "ml-auto border border-neutral-300"
                     )}
                   >
-                    {segment.text.trim()}
+                    <div className="flex flex-col">
+                      <span>{segment.text.trim()}</span>
+                      <span
+                        className={`text-xs text-gray-400 mt-1 ${
+                          participant?.isAgent
+                            ? "text-left block"
+                            : "text-right block"
+                        }`}
+                      >
+                        {new Date(timestamp).toLocaleTimeString([], {
+                          hour: "2-digit",
+                          minute: "2-digit",
+                          second: '2-digit',
+                        })}
+                      </span>
+                    </div>
                   </div>
-                ),
+                )
             )}
             <div ref={transcriptEndRef} />
           </div>

--- a/web/src/components/transcript.tsx
+++ b/web/src/components/transcript.tsx
@@ -19,7 +19,7 @@ export function Transcript({
 
   const handleScrollVisibility = (
     container: HTMLElement,
-    scrollButton: HTMLButtonElement
+    scrollButton: HTMLButtonElement,
   ) => {
     const distanceFromBottom = calculateDistanceFromBottom(container);
     const shouldShowButton = distanceFromBottom > 100;

--- a/web/src/components/transcript.tsx
+++ b/web/src/components/transcript.tsx
@@ -110,7 +110,7 @@ export function Transcript({
 
   return (
     <>
-      <div className="flex items-center justify-between sticky top-0 left-0 bg-white w-full p-4">
+      <div className="flex items-center justify-between bg-white w-full p-4 border-b sticky top-0 z-10">
         <h2 className="text-xs font-semibold uppercase tracking-widest">
           Transcript
         </h2>

--- a/web/src/components/transcript.tsx
+++ b/web/src/components/transcript.tsx
@@ -157,7 +157,7 @@ export function Transcript({
                       </span>
                     </div>
                   </div>
-                )
+                ),
             )}
             <div ref={transcriptEndRef} />
           </div>

--- a/web/src/components/transcript.tsx
+++ b/web/src/components/transcript.tsx
@@ -1,7 +1,6 @@
 import { cn } from "@/lib/utils";
 import { useAgent } from "@/hooks/use-agent";
 import { useEffect, useRef, RefObject, useState } from "react";
-// import { FaDownload } from 'react-icons/fa';
 
 export function Transcript({
   scrollContainerRef,

--- a/web/src/hooks/use-agent.tsx
+++ b/web/src/hooks/use-agent.tsx
@@ -14,7 +14,6 @@ import {
 } from "livekit-client";
 import { useConnection } from "@/hooks/use-connection";
 import { useToast } from "@/hooks/use-toast";
-
 interface Transcription {
   segment: TranscriptionSegment;
   participant?: Participant;
@@ -91,7 +90,7 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
     );
     const mergedSorted = sorted.reduce((acc, current) => {
       if (acc.length === 0) {
-      return [{...current, timestamp: current.segment.firstReceivedTime}];
+        return [{...current, timestamp: current.segment.firstReceivedTime}];
       }
 
       const last = acc[acc.length - 1];
@@ -119,7 +118,7 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
           },
         ];
       } else {
-      return [...acc, {...current, timestamp: current.segment.firstReceivedTime}];
+        return [...acc, {...current, timestamp: current.segment.firstReceivedTime}];
       }
     }, [] as Transcription[]);
     setDisplayTranscriptions(mergedSorted);

--- a/web/src/hooks/use-agent.tsx
+++ b/web/src/hooks/use-agent.tsx
@@ -14,10 +14,12 @@ import {
 } from "livekit-client";
 import { useConnection } from "@/hooks/use-connection";
 import { useToast } from "@/hooks/use-toast";
+
 interface Transcription {
   segment: TranscriptionSegment;
   participant?: Participant;
   publication?: TrackPublication;
+  timestamp?: number; // Add this line to include a timestamp
 }
 
 interface AgentContextType {
@@ -89,7 +91,7 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
     );
     const mergedSorted = sorted.reduce((acc, current) => {
       if (acc.length === 0) {
-        return [current];
+      return [{...current, timestamp: current.segment.firstReceivedTime}];
       }
 
       const last = acc[acc.length - 1];
@@ -113,10 +115,11 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
               id: current.segment.id, // Use the id of the latest segment
               firstReceivedTime: last.segment.firstReceivedTime, // Keep the original start time
             },
+            timestamp: last.timestamp, // Keep the earliest timestamp
           },
         ];
       } else {
-        return [...acc, current];
+      return [...acc, {...current, timestamp: current.segment.firstReceivedTime}];
       }
     }, [] as Transcription[]);
     setDisplayTranscriptions(mergedSorted);


### PR DESCRIPTION
# Changes
- Added "Download" button to export conversation transcript as CSV
- Added timestamps display for each message in transcript
- CSV includes timestamp, participant role (Agent/User), and message text
- Updated transcript UI to show timestamps below each message
- Fixed message merging logic to preserve original timestamps

# Implementation Details
- CSV export handles quote escaping and uses ISO date for filename
- Timestamps use 24-hour format with HH:mm:ss
- Preserved backward compatibility by making timestamp optional in Transcription interface
- Enhanced message merge logic to maintain chronological accuracy

# Testing
- [x] Verify CSV download contains all messages with correct timestamps
- [x] Confirm timestamps display correctly in UI
- [x] Test message merging with multiple rapid messages
- [x] Validate CSV formatting with messages containing quotes/special chars

# Chat Transcript 
![image](https://github.com/user-attachments/assets/d4a55af2-42aa-4b81-8e0c-c1d61e9ef0fd)

# Chat CSV
![image](https://github.com/user-attachments/assets/1934aa33-6b84-470d-9372-9158db105036)
