### PR TITLE
Enable krisp by default

### DIFF
--- a/web/src/components/session-controls.tsx
+++ b/web/src/components/session-controls.tsx
@@ -37,6 +37,9 @@ export function SessionControls() {
   const { isNoiseFilterEnabled, isNoiseFilterPending, setNoiseFilterEnabled } =
     useKrispNoiseFilter();
   useEffect(() => {
+    setNoiseFilterEnabled(true);
+  }, [setNoiseFilterEnabled]);
+  useEffect(() => {
     setIsMuted(localParticipant.isMicrophoneEnabled === false);
   }, [localParticipant.isMicrophoneEnabled]);
 


### PR DESCRIPTION
This ensures its always on unless you specifically turn it off (project allowing, of course)